### PR TITLE
Make list.txt and example code more intuitive

### DIFF
--- a/assets/gamemode/example.asm
+++ b/assets/gamemode/example.asm
@@ -1,0 +1,7 @@
+; This is an example code file for UberASMTool.
+; The code in this file does nothing.
+; By default, it runs everywhere on the overworld, because of the entry "0E example.asm" in the "gamemode" list (in the list.txt file).
+; You can safely remove that entry. After you do that, you can also safely remove this file.
+
+main:
+	rtl

--- a/assets/level/example.asm
+++ b/assets/level/example.asm
@@ -1,0 +1,7 @@
+; This is an example code file for UberASMTool.
+; The code in this file does nothing.
+; By default, it runs in level 105, because of the entry "105 example.asm" in the "level" list (in the list.txt file).
+; You can safely remove that entry. After you do that, you can also safely remove this file.
+
+main:
+	rtl

--- a/assets/level/test.asm
+++ b/assets/level/test.asm
@@ -1,5 +1,0 @@
-; Example code. Makes Mario crazy.
-
-main:
-	inc $19
-	rtl

--- a/assets/level/test2.asm
+++ b/assets/level/test2.asm
@@ -1,8 +1,0 @@
-; Example 2. Set Conditional DM16 flag 0 if the player has either Cape or Fire power-up.
-
-load:
-	lda $19
-	lsr
-	and #$01
-	sta $7FC060
-	rtl

--- a/assets/list.txt
+++ b/assets/list.txt
@@ -1,26 +1,97 @@
 verbose: on
 
-# UberASM Tool code list.
-# You can use the same .asm file for multiple levels/OW/etc. for saving space.
 
-# Level list. Valid values: 000-1FF.
+
+# UBERASM TOOL: LIST FILE
+# This is a list of all the code files you're using, and when to run them.
+
+
+
+# LEVEL CODE
+# Code files in this list will be run in specific levels.
+
+# EXAMPLE:
+# To run the code from the file "mycode.asm" in level 105,
+# put "mycode.asm" in the "level" folder
+# and add an entry to this list saying "105 mycode.asm"
+# (without the quotes, and without # in front).
+
+# - You can use the same code file in multiple levels!
+# - If you want to use multiple code files in the same level,
+#   check https://www.smwcentral.net/?p=faq&page=1515827-uberasm .
+# - To run the same code in every level, apply it to game mode 14 (see below).
+
 level:
-105		test.asm
-106		test2.asm
+        105 example.asm
 
-# OW list. Valid values: 0 = Main map; 1 = Yoshi's Island; 2 = Vanilla Dome;
-# 3 = Forest of Illusion; 4 = Valley of Bowser; 5 = Special World; and
-# 6 = Star World.
+
+
+
+
+# OVERWORLD CODE
+# Code files in this list will be run on specific overworld maps.
+
+# Each map has a number:
+# 0: Main Map
+# 1: Yoshi's Island
+# 2: Vanilla Dome
+# 3: Forest of Illusion
+# 4: Valley of Bowser
+# 5: Special World
+# 6: Star Road
+
+# EXAMPLE:
+# To run the code from the file "mycode.asm" on the Vanilla Dome map,
+# put "mycode.asm" in the "overworld" folder
+# and add an entry to this list saying "2 mycode.asm"
+# (without the quotes, and without # in front).
+
 overworld:
-# Insert files here
+        1 example.asm
 
-# Game mode list. Valid values: 00-FF.
+
+
+
+
+# GAME MODE CODE
+# Code files in this list will be run during specific game modes.
+
+# Some common game modes are:
+# 01: "Nintendo Presents" screen
+# 07: Title Screen
+# 08: Title Screen (File select)
+# 0E: Overworld
+# 14: Level
+# You can also define your own (from 2A to FF).
+
+# EXAMPLE:
+# To run the code from the file "mycode.asm" in game mode 14 (i.e. in all levels),
+# put "mycode.asm" in the "gamemode" folder
+# and add an entry to this list saying "14 mycode.asm"
+# (without the quotes, and without # in front).
+
 gamemode:
-# Insert files here
+        0E example.asm
 
-global:		other/global_code.asm	# global code.
-statusbar:	other/status_code.asm	# status bar code.
-macrolib:	other/macro_library.asm	# macro library.
-sprite:		$7FAC80			# 38 (SNES) or 68 (SA-1) bytes of free RAM.
-sprite-sa1:	$41AC80			# Optional for SA-1 ROMs.
-rom:		SMW.smc			# ROM file to use.
+
+
+
+
+# OTHER OPTIONS
+
+# Global code - this will be run all the time.
+global:         other/global_code.asm
+
+# Status bar code - this will be run when the status bar is drawn to the screen.
+statusbar:      other/status_code.asm
+
+# A file containing macros.
+macrolib:       other/macro_library.asm
+
+# Sprite-related RAM (see README). You probably don't need to change this.
+sprite:         $7FAC80   # 38 (SNES) or 68 (SA-1) bytes of free RAM.
+sprite-sa1:     $41AC80   # Optional for SA-1 ROMs.
+
+# The name of your ROM file - this will be used if you don't specify a ROM name
+# when running UberASM Tool.
+rom:            SMW.smc

--- a/assets/overworld/example.asm
+++ b/assets/overworld/example.asm
@@ -1,0 +1,7 @@
+; This is an example code file for UberASMTool.
+; The code in this file does nothing.
+; By default, it runs on the Yoshi's Island map, because of the entry "1 example.asm" in the "overworld" list (in the list.txt file).
+; You can safely remove that entry. After you do that, you can also safely remove this file.
+
+main:
+	rtl


### PR DESCRIPTION
Over the past few years, many people have mistaken the effects of the example code for a bug, because they didn't know that it was there, and that the entries in list.txt existed. It's become clear that the presence of the example code is confusing, or wasn't conveyed well.

I have attempted to fix this by:
- changing list.txt to be tidier and easier to read
- including more eye-catching info on how to use the lists in list.txt
- giving each list exactly one example entry, with its own code file that does nothing (the files have a comment in them explaining that they can be removed, but, crucially, nothing weird happens if they aren't removed).